### PR TITLE
Add admin RBAC option

### DIFF
--- a/charts/porter/Chart.yaml
+++ b/charts/porter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/porter/templates/cluster-role-binding.yaml
+++ b/charts/porter/templates/cluster-role-binding.yaml
@@ -4,9 +4,15 @@ metadata:
   name: {{ include "porter.fullname" . }}
   labels: {{- include "porter.labels" . | nindent 4 }}
 roleRef:
+  {{- if .Values.server.setAdminRBAC }}
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "cluster-admin"
+  {{- else }}
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ include "porter.fullname" . }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "porter.serviceAccountName" . }}

--- a/charts/porter/templates/cluster-role.yaml
+++ b/charts/porter/templates/cluster-role.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.server.setAdminRBAC }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -9,7 +10,21 @@ rules:
     resources: ["namespaces"]
     verbs: ["get", "list", "create"]
   - apiGroups: [""]
-    resources: ["pods", "secrets", "configmaps", "pods/log", "pods/proxy", "pods/portforward", "pods/exec", "serviceaccounts", "services", "services/proxy"]
+    resources: [
+      "pods", 
+      "secrets", 
+      "configmaps", 
+      "pods/log", 
+      "pods/proxy", 
+      "pods/portforward", 
+      "pods/exec", 
+      "serviceaccounts", 
+      "services", 
+      "services/proxy",
+    ]
+    verbs: ["*"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
     verbs: ["*"]
   - apiGroups: ["apps"]
     resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
@@ -32,3 +47,4 @@ rules:
   {{- else }}
   []
   {{- end }}
+{{- end }}

--- a/charts/porter/values.yaml
+++ b/charts/porter/values.yaml
@@ -17,6 +17,10 @@ server:
 
   port: 8080
 
+  # setAdminRBAC allows the Porter dashboard system:masters access to the cluster, otherwise a separate clusterrole
+  # is created for the Porter user.
+  setAdminRBAC: false
+
   postgres: {}
   # if bringing your own postgres:
     # port: 5432


### PR DESCRIPTION
Allows users to bind Porter user to `system:masters` if desired.