### PR TITLE
Automate releases using a workflow dispatch event 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,41 @@
+name: Push to Helm chart repo
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: New Porter image tag version
+        default: v0.30.0
+        required: true
+jobs:
+  build:
+    environment: production
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: azure/setup-helm@v1
+        with:
+          version: 'v3.3.4'
+      - name: Install yq
+        run: |
+          wget https://github.com/mikefarah/yq/releases/download/v4.7.1/yq_linux_amd64 -O ./yq
+          chmod +x ./yq
+          sudo mv ./yq /usr/local/bin/yq
+      - name: Bump the Porter image tag
+        run: |
+          yq eval ".image.tag = \"$PORTER_IMAGE_TAG\"" -i ./charts/porter/values.yaml
+      - name: Build modified charts
+        run: |
+          ./scripts/build.sh charts ${{ github.sha }} ${{ github.event.before }}
+        env:
+          CHARTMUSEUM_USERNAME: ${{ secrets.CHARTMUSEUM_SELF_HOSTED_USERNAME }}
+          CHARTMUSEUM_PASSWORD: ${{ secrets.CHARTMUSEUM_SELF_HOSTED_PASSWORD }}
+          CHARTMUSEUM_URL: ${{ secrets.CHARTMUSEUM_SELF_HOSTED_URL }}
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update Chart.yaml and values.yaml versions
+          commit_options: '--allow-empty'
+          file_pattern: "*/*/*.yaml"
+          commit_user_name: Porter Bot
+          commit_user_email: contact@getporter.dev

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
           sudo mv ./yq /usr/local/bin/yq
       - name: Bump the Porter image tag
         run: |
-          yq eval ".image.tag = \"$PORTER_IMAGE_TAG\"" -i ./charts/porter/values.yaml
+          yq eval ".image.tag = \"${{ github.event.inputs.version }}\"" -i ./charts/porter/values.yaml
       - name: Build modified charts
         run: |
           ./scripts/build.sh charts ${{ github.sha }} ${{ github.event.before }}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+versionJQ='
+def handle: .[] | [.version] | sort_by( split(".") | map(tonumber) ) | last ;
+def error: "" ;
+def process: try handle catch error;
+process'
+
+# Based on: https://github.com/fmahnke/shell-semver/blob/master/increment_version.sh
+# Increment a version string using Semantic Versioning (SemVer) terminology.
+increment_version () {
+    # Parse command line options.
+
+    while getopts ":Mmp" Option
+    do
+    case $Option in
+        M ) major=true;;
+        m ) minor=true;;
+        p ) patch=true;;
+    esac
+    done
+
+    shift $(($OPTIND - 1))
+
+    version=$1
+
+    # Build array from version string.
+
+    a=( ${version//./ } )
+
+    # If version string is missing or has the wrong number of members, show usage message.
+
+    if [ ${#a[@]} -ne 3 ]
+    then
+    echo "usage: $(basename $0) [-Mmp] major.minor.patch"
+    exit 1
+    fi
+
+    # Increment version numbers as requested.
+
+    if [ ! -z $major ]
+    then
+    ((a[0]++))
+    a[1]=0
+    a[2]=0
+    fi
+
+    if [ ! -z $minor ]
+    then
+    ((a[1]++))
+    a[2]=0
+    fi
+
+    if [ ! -z $patch ]
+    then
+    ((a[2]++))
+    fi
+
+    echo "${a[0]}.${a[1]}.${a[2]}"
+}
+
+package_helm() {
+  local helm_dir=$1
+
+  echo "Packaging chart found in directory $1"
+
+  # get latest version from chartmuseum
+  name=$(yq e '.name' $2)
+  version=$(curl -s "$CHARTMUSEUM_URL/api/charts/$name" | jq -r "$versionJQ")
+
+  if [ -z $version ]
+  then
+    version="0.0.0"
+  fi
+
+  # increment version
+  new_version=$(increment_version -m $version)
+
+  echo "Upgrading $name from $version to $new_version"
+
+  yq e '.version = "'"$new_version"'"' -i $2
+
+  helm package $helm_dir
+}
+
+for d in $1/*/Chart.yaml ; do
+  helm_dir=$(echo "$d" | sed 's|\(.*\)/.*|\1|')
+
+  echo "Checking diffs for $helm_dir"
+  
+  git diff --quiet $2 $3 -- $helm_dir || package_helm $helm_dir $d
+done
+
+if ls *.tgz 1> /dev/null 2>&1; then
+  for file in *.tgz ; do
+    echo "Uploading package $file to chartmuseum"
+
+    curl -s -u $CHARTMUSEUM_USERNAME:$CHARTMUSEUM_PASSWORD --data-binary "@$file" "$CHARTMUSEUM_URL/api/charts"
+  done
+
+  # cleanup files 
+  rm *.tgz
+else
+  echo "No tgz files found"
+fi


### PR DESCRIPTION
Adds support for automating the publishing of new Helm releases for the porter-self-hosted chart.