### PR TITLE
Add options for `aws-auth` configmap 

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ output "db_master_password" {
 }
 ```
 
-Then, run `terraform init` and `terraform apply`. To output the values from RDS, run `terraform output -json`. 
+Then, run `terraform init` and `terraform apply`. To output the values from RDS, run `terraform output -json`.
 
 ### Step 5: Install Porter Helm chart
 
@@ -168,3 +168,21 @@ server:
 ```
 
 Then, run `helm install porter ../charts/porter --values values.yaml`.
+
+### Adding Users to the Cluster
+
+To add users to the cluster, the following variable declarations are supported in `.infra/eks/main.tf`:
+
+```
+manage_aws_auth_configmap = true
+
+aws_auth_users = {
+  arn: "<user-arn>",
+  group: "system:masters", // the group on the cluster
+}
+
+aws_auth_roles = {
+  arn: "<role-arn>",
+  group: "system:masters", // the group on the cluster
+}
+```

--- a/modules/aws/eks/eks.tf
+++ b/modules/aws/eks/eks.tf
@@ -63,7 +63,26 @@ module "eks" {
   cluster_name    = var.env_name
   cluster_version = var.cluster_version
   subnets         = var.private_subnets
-  enable_irsa     = true
+
+  manage_aws_auth = var.manage_aws_auth_configmap
+
+  map_roles = [
+    for arn, group in var.aws_auth_roles : {
+      rolearn  = arn
+      username = split("/", arn)[1]
+      groups   = [group]
+    }
+  ]
+
+  map_users = [
+    for arn, group in var.aws_auth_users : {
+      userarn  = arn
+      username = split("/", arn)[1]
+      groups   = [group]
+    }
+  ]
+
+  enable_irsa = true
 
   vpc_id = var.vpc_id
 

--- a/modules/aws/eks/variables.tf
+++ b/modules/aws/eks/variables.tf
@@ -115,3 +115,20 @@ variable "spot_price" {
   type    = string
   default = ""
 }
+
+variable "manage_aws_auth_configmap" {
+  type    = bool
+  default = true
+}
+
+variable "aws_auth_users" {
+  type = map(any)
+
+  default = {}
+}
+
+variable "aws_auth_roles" {
+  type = map(any)
+
+  default = {}
+}


### PR DESCRIPTION
Add `mapUsers` and `mapRoles` options to set in the `aws-auth` ConfigMap on the cluster.